### PR TITLE
Fix stray semicolon on HomePage

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -75,5 +75,5 @@ export default function HomePage() {
             </ul>
         </ul>
     </div>
-  </div>;
+  </div>
 }


### PR DESCRIPTION
## Summary
- remove an extraneous semicolon at the end of `HomePage.tsx`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686495006b788322be2892f571251e45